### PR TITLE
add log4j to project, example of usage in ScannerTest class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ repositories {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.2'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.2'
+
 }
 
 test {

--- a/logs/compiler.log
+++ b/logs/compiler.log
@@ -1,0 +1,1 @@
+Testing log with log4j from: syntatic.analyzer.Scanner

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,12 @@
+status = warn
+
+name = PropertiesConfig
+appender = file
+appender.file.type = File
+appender.file.name = FileLogger
+appender.file.filename = logs/log.log
+appender.file.leyout.type = PatternLayout
+
+rootLogger.level = debug
+rootLogger.appenderRef = file
+rootLogger.appenderRef.file.ref = FileLogger

--- a/src/test/java/ScannerTest.java
+++ b/src/test/java/ScannerTest.java
@@ -1,3 +1,5 @@
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import syntatic.analyzer.Scanner;
 import syntatic.analyzer.SourceFile;
 import syntatic.analyzer.Token;
@@ -9,11 +11,19 @@ public class ScannerTest {
 
     // TODO make into a class with unit tests instead
     // import .txt files for testing into C:\git\shortsy-compiler\src\test\resources instead of local machine
+    /**
+     * Example of how to use the logger
+     * 1) create a private field of type Logger initiated with the name of the class in which is used
+     * 2) Set the system property of log4j.configurationFile to point to the location where the log4j properties are defined
+     */
     private static final String EXAMPLES_DIR = "C:/Users/Pál Jámbor/Desktop/example.txt";
-
+    private static final Logger logger = LogManager.getLogger(ScannerTest.class);
 
     public static void main( String args[] )
     {
+        System.setProperty("log4j.configurationFile", "src/main/resources/log4j2.properties");
+        logger.debug(String.format("Testing log with log4j from: %s", Scanner.class.getName()));
+
         JFileChooser fc = new JFileChooser( EXAMPLES_DIR );
 
         if( fc.showOpenDialog( null ) == JFileChooser.APPROVE_OPTION ) {


### PR DESCRIPTION
Adding log4j as a solution for logging outputs and debugging code